### PR TITLE
Add support for ampere GPUs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-ARG PYTORCH="1.4"
-ARG CUDA="10.1"
-ARG CUDNN="7"
+ARG PYTORCH="1.10.0"
+ARG CUDA="11.3"
+ARG CUDNN="8"
 
 FROM pytorch/pytorch:${PYTORCH}-cuda${CUDA}-cudnn${CUDNN}-devel
 
-ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX"
 ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
@@ -13,7 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Berlin
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN apt-get update && apt-get install -y libglib2.0-0 libsm6 libxrender-dev libxext6 nano mc glances vim \
+RUN apt-get update && apt-get install -y libglib2.0-0 libsm6 libxrender-dev libxext6 nano mc glances vim git \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
@@ -31,36 +30,13 @@ RUN apt-get install libopenblas-dev liblapack-dev -y
 RUN apt-get install libx11-dev libgtk-3-dev -y
 RUN pip install dlib
 RUN pip install facenet-pytorch
-RUN conda install \
-              pyhamcrest \
-              cython \
-              fiona \
-              h5py \
-              jupyter \
-              jupyterlab \
-              ipykernel \
-              matplotlib \
-	          ncurses \
-              numpy \
-			  statsmodels \
-              pandas \
-              pillow \
-              pip \
-              scipy \
-              scikit-image \
-              scikit-learn \
-              testpath \
-              tqdm \
-              pandas \
-			  opencv \
-	&& conda clean -p \
-	&& conda clean -t \
-	&& conda clean --yes --all
-RUN pip install albumentations timm pytorch_toolbelt tensorboardx
+RUN pip install albumentations==1.0.0 timm==0.4.12 pytorch_toolbelt tensorboardx
+RUN pip install cython jupyter  jupyterlab ipykernel matplotlib tqdm pandas
+
 # download pretraned Imagenet models
 RUN apt install wget
-RUN wget https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b7_ns-1dbc32de.pth -P /root/.cache/torch/checkpoints/
-RUN wget https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b5_ns-6f26d0cf.pth -P /root/.cache/torch/checkpoints/
+RUN wget https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b7_ns-1dbc32de.pth -P /root/.cache/torch/hub/checkpoints/
+RUN wget https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/tf_efficientnet_b5_ns-6f26d0cf.pth -P /root/.cache/torch/hub/checkpoints/
 
 # Setting the working directory
 WORKDIR /workspace

--- a/predict_folder.py
+++ b/predict_folder.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     strategy = confident_strategy
     stime = time.time()
 
-    test_videos = sorted([x for x in os.listdir(args.test_dir) if x[-4:] == ".mp4"])[:10]
+    test_videos = sorted([x for x in os.listdir(args.test_dir) if x[-4:] == ".mp4"])
     print("Predicting {} videos".format(len(test_videos)))
     predictions = predict_on_video_set(face_extractor=face_extractor, input_size=input_size, models=models,
                                        strategy=strategy, frames_per_video=frames_per_video, videos=test_videos,

--- a/predict_folder.py
+++ b/predict_folder.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
         print("loading state dict {}".format(path))
         checkpoint = torch.load(path, map_location="cpu")
         state_dict = checkpoint.get("state_dict", checkpoint)
-        model.load_state_dict({re.sub("^module.", "", k): v for k, v in state_dict.items()}, strict=False)
+        model.load_state_dict({re.sub("^module.", "", k): v for k, v in state_dict.items()}, strict=True)
         model.eval()
         del checkpoint
         models.append(model.half())
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     strategy = confident_strategy
     stime = time.time()
 
-    test_videos = sorted([x for x in os.listdir(args.test_dir) if x[-4:] == ".mp4"])
+    test_videos = sorted([x for x in os.listdir(args.test_dir) if x[-4:] == ".mp4"])[:10]
     print("Predicting {} videos".format(len(test_videos)))
     predictions = predict_on_video_set(face_extractor=face_extractor, input_size=input_size, models=models,
                                        strategy=strategy, frames_per_video=frames_per_video, videos=test_videos,

--- a/training/zoo/classifiers.py
+++ b/training/zoo/classifiers.py
@@ -2,25 +2,14 @@ from functools import partial
 
 import numpy as np
 import torch
-from timm.models import skresnext50_32x4d
-from timm.models.dpn import dpn92, dpn131
 from timm.models.efficientnet import tf_efficientnet_b4_ns, tf_efficientnet_b3_ns, \
     tf_efficientnet_b5_ns, tf_efficientnet_b2_ns, tf_efficientnet_b6_ns, tf_efficientnet_b7_ns
-from timm.models.senet import seresnext50_32x4d
 from torch import nn
 from torch.nn.modules.dropout import Dropout
 from torch.nn.modules.linear import Linear
 from torch.nn.modules.pooling import AdaptiveAvgPool2d
 
 encoder_params = {
-    "dpn92": {
-        "features": 2688,
-        "init_op": partial(dpn92, pretrained=True)
-    },
-    "dpn131": {
-        "features": 2688,
-        "init_op": partial(dpn131, pretrained=True)
-    },
     "tf_efficientnet_b3_ns": {
         "features": 1536,
         "init_op": partial(tf_efficientnet_b3_ns, pretrained=True, drop_path_rate=0.2)
@@ -60,14 +49,6 @@ encoder_params = {
     "tf_efficientnet_b6_ns_04d": {
         "features": 2304,
         "init_op": partial(tf_efficientnet_b6_ns, pretrained=True, drop_path_rate=0.4)
-    },
-    "se50": {
-        "features": 2048,
-        "init_op": partial(seresnext50_32x4d, pretrained=True)
-    },
-    "sk50": {
-        "features": 2048,
-        "init_op": partial(skresnext50_32x4d, pretrained=True)
     },
 }
 


### PR DESCRIPTION
Bumped up cuda/cudnn/torch/timm versions to support 3090 gpus.

Don't have time to download full dfdc set to test training code though.

Could not reproduce #25 issue.
On the first 10 videos from `test_videos` folder, which were actually in the validation holdout, predictions definitely make sense.
```
filename,label
aassnaulhq.mp4,0.978
aayfryxljh.mp4,0.00798
acazlolrpz.mp4,0.7793
adohdulfwb.mp4,0.01239
ahjnxtiamx.mp4,0.9907
ajiyrjfyzp.mp4,0.3713
aktnlyqpah.mp4,0.989
alrtntfxtd.mp4,0.775
aomqqjipcp.mp4,0.9907
apedduehoy.mp4,0.03763
```